### PR TITLE
fix text format

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -18,7 +18,7 @@ while true
         stream.user(){|toot|
             # Tweet My Toot
             if toot.account.url === "#{ENV["MASTODON_URL"]}/@#{ENV["MASTODON_USERNAME"]}"
-                puts tweet = toot.content.gsub(/^<p>|<\/p>/, '')
+                puts tweet = toot.content.gsub(/<\/p><p>/, "\n\n").gsub(/<\/?(p|a|span).*?>/, '')
                 client.update(tweet)
             end
         }


### PR DESCRIPTION
HTMLタグを除去する部分の修正
- `toot.content`にはAタグおよびSPANタグが含まれる可能性があります
- トゥートには複数のPタグが含まれる可能性があります（改行2つ扱い）